### PR TITLE
Use downloads.wkhtmltopdf.org for downloads

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -11,7 +11,7 @@
 
 - name: "Download deb file for wkhtmltopdf"
   get_url: >
-    url="http://download.gna.org/wkhtmltopdf/{{ wkhtmltopdf_version_main }}/{{ wkhtmltopdf_version_full }}/wkhtmltox-{{ wkhtmltopdf_version_full }}_linux-centos{{ansible_distribution_major_version}}-{{ wkhtmltopdf_architecture }}.rpm"
+    url="https://downloads.wkhtmltopdf.org/{{ wkhtmltopdf_version_main }}/{{ wkhtmltopdf_version_full }}/wkhtmltox-{{ wkhtmltopdf_version_full }}_linux-centos{{ansible_distribution_major_version}}-{{ wkhtmltopdf_architecture }}.rpm"
     dest="/tmp/wkhtmltox-{{ wkhtmltopdf_version_full }}_linux-centos{{ansible_distribution_major_version}}-{{ wkhtmltopdf_architecture }}.rpm"
   tags:
     - wkhtmltopdf

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -39,7 +39,7 @@
 
 - name: "Download deb file for wkhtmltopdf"
   get_url: >
-    url="http://download.gna.org/wkhtmltopdf/{{ wkhtmltopdf_version_main }}/{{ wkhtmltopdf_version_full }}/wkhtmltox-{{ wkhtmltopdf_version_full }}_linux-{{ ansible_distribution_release }}-{{ wkhtmltopdf_architecture }}.deb"
+    url="https://downloads.wkhtmltopdf.org/{{ wkhtmltopdf_version_main }}/{{ wkhtmltopdf_version_full }}/wkhtmltox-{{ wkhtmltopdf_version_full }}_linux-{{ ansible_distribution_release }}-{{ wkhtmltopdf_architecture }}.deb"
     dest="/tmp/wkhtmltox-{{ wkhtmltopdf_version_full }}_linux-{{ ansible_distribution_release }}-{{ wkhtmltopdf_architecture }}.deb"
   tags:
     - wkhtmltopdf


### PR DESCRIPTION
wkhtmltopdf [no longer uses](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3390) gna.org to host downloads, and instead uses downloads.wkhtmltopdf.org.